### PR TITLE
switch from resource location to resource key usage

### DIFF
--- a/src/main/java/me/alfie/immersiveenchanting/ImmersiveEnchanting.java
+++ b/src/main/java/me/alfie/immersiveenchanting/ImmersiveEnchanting.java
@@ -92,14 +92,11 @@ public class ImmersiveEnchanting {
     /**
      * Automatically get an enchantment holder using RegistryAccess.
      * @param access
-     * @param enchantmentResourceId
+     * @param enchantment
      * @return
      */
-    public static Optional<Holder.Reference<Enchantment>> getEnchantmentHolder(RegistryAccess access, String enchantmentResourceId) {
-        return getEnchantmentHolder(
-                getEnchantmentHolderLookup(access),
-                enchantmentResourceId
-        );
+    public static Optional<Holder.Reference<Enchantment>> getEnchantmentHolder(RegistryAccess access, ResourceKey<Enchantment> enchantment) {
+        return access.registryOrThrow(Registries.ENCHANTMENT).getHolder(enchantment);
     }
 
     public static ResourceLocation getEnchantmentHolderRL(Holder<Enchantment> enchantmentHolder) {

--- a/src/main/java/me/alfie/immersiveenchanting/datapack/EnchantmentCostDatapackHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/datapack/EnchantmentCostDatapackHandler.java
@@ -5,8 +5,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import me.alfie.immersiveenchanting.ImmersiveEnchanting;
 import me.alfie.immersiveenchanting.networking.packets.EnchantmentCostRegistrySyncPacket;
-import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
@@ -16,7 +17,6 @@ import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
-import net.neoforged.neoforge.registries.NeoForgeRegistries;
 
 import java.util.Map;
 
@@ -77,7 +77,8 @@ public class EnchantmentCostDatapackHandler extends SimpleJsonResourceReloadList
             }
 
             // Put enchantment cost into registry
-            EnchantmentCostRegistry.getServerRegistry().getCostRegistry().put(enchantmentResourceLocation, enchantmentCost);
+            EnchantmentCostRegistry.getServerRegistry().getCostRegistry()
+                    .put(ResourceKey.create(Registries.ENCHANTMENT, enchantmentResourceLocation), enchantmentCost);
 
             recipeCount++;
         }

--- a/src/main/java/me/alfie/immersiveenchanting/datapack/EnchantmentCostRegistry.java
+++ b/src/main/java/me/alfie/immersiveenchanting/datapack/EnchantmentCostRegistry.java
@@ -1,7 +1,8 @@
 package me.alfie.immersiveenchanting.datapack;
 
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.enchantment.Enchantment;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,27 +30,27 @@ public class EnchantmentCostRegistry {
     }
 
     // Maps the enchantment ResourceLocation (e.g., minecraft:efficiency) to its cost data
-    private final Map<ResourceLocation, EnchantmentCost> COST_REGISTRY = new HashMap<>();
+    private final Map<ResourceKey<Enchantment>, EnchantmentCost> COST_REGISTRY = new HashMap<>();
     private ItemStack lapisCost;
     public static final EnchantmentCost EMPTY = new EnchantmentCost();
 
     /**
      * Helper method to get enchantment cost from COST_REGISTRY from its resource location.
-     * @param enchantmentNamespace
+     * @param enchantment
      * @return
      */
-    public EnchantmentCost getEnchantmentCost(ResourceLocation enchantmentNamespace) {
-        return this.COST_REGISTRY.getOrDefault(enchantmentNamespace, EMPTY);
+    public EnchantmentCost getEnchantmentCost(ResourceKey<Enchantment> enchantment) {
+        return this.COST_REGISTRY.getOrDefault(enchantment, EMPTY);
     }
 
     /**
      * Helper method to get a specific level cost for an enchantment using its resource location.
-     * @param enchantmentId
+     * @param enchantment
      * @param level
      * @return
      */
-    public LevelCost getLevelCost(ResourceLocation enchantmentId, int level) {
-        EnchantmentCost data = this.COST_REGISTRY.get(enchantmentId);
+    public LevelCost getLevelCost(ResourceKey<Enchantment> enchantment, int level) {
+        EnchantmentCost data = this.COST_REGISTRY.get(enchantment);
         if (data == null) return null;
         return data.getLevel(level);
     }
@@ -76,7 +77,7 @@ public class EnchantmentCostRegistry {
      * Returns the cost registry map <ResourceLocation, EnchantmentCost>
      * @return
      */
-    public Map<ResourceLocation, EnchantmentCost> getCostRegistry() {
+    public Map<ResourceKey<Enchantment>, EnchantmentCost> getCostRegistry() {
         return this.COST_REGISTRY;
     }
 

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNode.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNode.java
@@ -1,10 +1,8 @@
 package me.alfie.immersiveenchanting.gui;
 
-import me.alfie.immersiveenchanting.ImmersiveEnchanting;
 import me.alfie.immersiveenchanting.enums.EnchantingNodeType;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.core.Holder;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -33,11 +31,7 @@ public class EnchantingNode {
         this.isBranchUnlocked = isBranchUnlocked;
         this.enchantmentLevel = enchantmentLevel;
         this.enchantmentHolder = enchantmentHolder;
-
-        ResourceLocation enchantmentRL = ImmersiveEnchanting.getEnchantmentHolderRL(enchantmentHolder);
-
-        ResourceKey<Enchantment> key = ResourceKey.create(Registries.ENCHANTMENT, enchantmentRL);
-        this.enchantment = key;
+        this.enchantment = enchantmentHolder.getKey();
 
         if (isBranchUnlocked) {
             this.node_type = node_type;

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeBranch.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeBranch.java
@@ -10,6 +10,7 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.texture.DynamicTexture;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.enchantment.Enchantment;
@@ -54,7 +55,9 @@ public class EnchantingNodeBranch {
         //Using default texture for now
         ResourceLocation icon_texture = ResourceLocation.fromNamespaceAndPath("immersiveenchanting", "textures/item/ancient_book.png");
 
-        ResourceLocation enchantmentRL = ImmersiveEnchanting.getEnchantmentHolderRL(enchantmentHolder);
+        ResourceKey<Enchantment> enchantmentKey = enchantmentHolder.getKey();
+        //noinspection DataFlowIssue -> Holder.Reference, meaning key is present
+        ResourceLocation enchantmentRL = enchantmentKey.location();
 
         //Try to get an icon
         if (EnchantmentMetadataRegistry.getIcons().containsKey(enchantmentRL)) {
@@ -64,12 +67,12 @@ public class EnchantingNodeBranch {
 
         //Get the max level, if 10 levels are in the config, then player can get level 10 enchantments.
         int maxEnchantmentLevel;
-        if(EnchantmentCostRegistry.getClientRegistry().getCostRegistry().containsKey(enchantmentRL)) {
-            maxEnchantmentLevel = EnchantmentCostRegistry.getClientRegistry().getEnchantmentCost(enchantmentRL).getHighestLevel();
+        if(EnchantmentCostRegistry.getClientRegistry().getCostRegistry().containsKey(enchantmentKey)) {
+            maxEnchantmentLevel = EnchantmentCostRegistry.getClientRegistry().getEnchantmentCost(enchantmentKey).getHighestLevel();
         } else {
             //Fallback if there is no enchantment cost set up, use the default max level from the enchantment
             Registry<Enchantment> enchantmentRegistry = ImmersiveEnchanting.getEnchantmentRegistry(player.registryAccess());
-            maxEnchantmentLevel = enchantmentRegistry.get(enchantmentRL).getMaxLevel();
+            maxEnchantmentLevel = enchantmentRegistry.get(enchantmentKey).getMaxLevel();
         }
 
         //Reveal ladder up to (equippedLevel + 1).

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingTableScreen.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingTableScreen.java
@@ -11,6 +11,7 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.core.Holder;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.tags.EnchantmentTags;
@@ -281,8 +282,8 @@ public class EnchantingTableScreen extends AbstractContainerScreen<EnchantingTab
                     guiGraphics.pose().translate(0, 0, 400);
 
                     if (renderCostStack == null) {
-                        renderCostStack = EnchantmentCostRegistry.getClientRegistry().getEnchantmentCost(
-                                ImmersiveEnchanting.getEnchantmentHolderRL(node.getEnchantmentHolder()))
+                        renderCostStack = EnchantmentCostRegistry.getClientRegistry()
+                                .getEnchantmentCost(node.getEnchantmentHolder().getKey())
                                 .getLevel(node.getEnchantmentLevel())
                                 .asItemStack();
                     }
@@ -382,13 +383,12 @@ public class EnchantingTableScreen extends AbstractContainerScreen<EnchantingTab
                 continue;
             }
 
-            String enchantmentResourceId = enchantmentHolder.getRegisteredName();
-            ResourceLocation enchantmentResourceLocation = ResourceLocation.tryParse(enchantmentResourceId);
+            ResourceKey<Enchantment> enchantmentKey = enchantmentHolder.getKey();
 
             //If enchantment has DO_NOT_INCLUDE tag. (Empty json)
-            if(EnchantmentCostRegistry.getClientRegistry().getCostRegistry().containsKey(enchantmentResourceLocation)) {
+            if(EnchantmentCostRegistry.getClientRegistry().getCostRegistry().containsKey(enchantmentKey)) {
                 if(EnchantmentCostRegistry.getClientRegistry().getCostRegistry()
-                        .get(enchantmentResourceLocation)
+                        .get(enchantmentKey)
                         .getLevel(-1).item().equals(LevelCost.DO_NOT_INCLUDE)) {
                     continue;
                 }
@@ -585,7 +585,7 @@ public class EnchantingTableScreen extends AbstractContainerScreen<EnchantingTab
             //Server uses RESOURCE_KEY_MAP.get() to find the corresponding ResourceKey
             //Server enchants tool, client side cannot do it.
             PacketDistributor.sendToServer(new EnchantItemPacket(
-                    node.getEnchantmentHolder().getRegisteredName(),
+                    node.getEnchantmentHolder().getKey(),
                     node.getEnchantmentLevel())
             );
         }

--- a/src/main/java/me/alfie/immersiveenchanting/lootmodifier/AncientBookLootModifier.java
+++ b/src/main/java/me/alfie/immersiveenchanting/lootmodifier/AncientBookLootModifier.java
@@ -86,9 +86,9 @@ public class AncientBookLootModifier extends LootModifier {
 
                             //BUG-FIX! Cannot access getClientRegistry() here, as this method runs server-side.
                             //Use getServerRegistry()
-                            if(EnchantmentCostRegistry.getServerRegistry().getCostRegistry().containsKey(enchantment.key().location())) {
+                            if(EnchantmentCostRegistry.getServerRegistry().getCostRegistry().containsKey(enchantment.key())) {
                                 if(EnchantmentCostRegistry.getServerRegistry().getCostRegistry()
-                                        .get(enchantment.key().location())
+                                        .get(enchantment.key())
                                         .getLevel(-1).item().equals(LevelCost.DO_NOT_INCLUDE)) {
                                     return false;
                                 }

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ClientPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ClientPayloadHandler.java
@@ -6,6 +6,7 @@ import me.alfie.immersiveenchanting.gui.EnchantingTableMenu;
 import me.alfie.immersiveenchanting.networking.packets.EnchantmentCostRegistrySyncPacket;
 import me.alfie.immersiveenchanting.networking.packets.UnlockedEnchantmentsPacket;
 import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
@@ -48,11 +49,11 @@ public class ClientPayloadHandler {
      * @param context
      */
     public static void onUnlockedEnchantments(final UnlockedEnchantmentsPacket packet, final IPayloadContext context) {
-        Set<String> unlockedEnchantmentResourceIds = new HashSet<>(packet.enchantments());
+        Set<ResourceKey<Enchantment>> unlockedEnchantmentResourceIds = new HashSet<>(packet.enchantments());
 
         Set<Holder<Enchantment>> unlockedEnchantments = new HashSet<>();
-        for (String resourceId : unlockedEnchantmentResourceIds) {
-            ImmersiveEnchanting.getEnchantmentHolder(context.player().registryAccess(), resourceId)
+        for (ResourceKey<Enchantment> enchantmentKey : unlockedEnchantmentResourceIds) {
+            ImmersiveEnchanting.getEnchantmentHolder(context.player().registryAccess(), enchantmentKey)
                     .ifPresent(unlockedEnchantments::add);
         }
 

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
@@ -10,21 +10,21 @@ import me.alfie.immersiveenchanting.item.ModItems;
 import me.alfie.immersiveenchanting.networking.packets.EnchantItemPacket;
 import me.alfie.immersiveenchanting.networking.packets.GetBookshelfContentsPacket;
 import me.alfie.immersiveenchanting.networking.packets.UnlockedEnchantmentsPacket;
-import net.minecraft.advancements.Advancement;
-import net.minecraft.advancements.AdvancementHolder;
-import net.minecraft.advancements.AdvancementProgress;
+import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.stats.Stats;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -55,16 +55,16 @@ public class ServerPayloadHandler {
         RegistryAccess registryAccess = player.registryAccess();
         Optional<Holder.Reference<Enchantment>> enchantmentHolder = ImmersiveEnchanting.getEnchantmentHolder(
                 registryAccess,
-                packet.enchantmentResourceId()
+                packet.enchantment()
         );
 
         Holder<Enchantment> enchantment = enchantmentHolder.orElseThrow(() ->
-                new IllegalStateException("Enchantment not found: " + packet.enchantmentResourceId())
+                new IllegalStateException("Enchantment not found: " + packet.enchantment())
         );
 
         //Check enchantment cost
         ItemStack costSlotItemStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.COST.ordinal()).getItem();
-        ItemStack requiredItemCostStack = EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(ResourceLocation.parse(packet.enchantmentResourceId())).getLevel(packet.enchantmentLevel()).asItemStack();
+        ItemStack requiredItemCostStack = EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(packet.enchantment()).getLevel(packet.enchantmentLevel()).asItemStack();
 
         ItemStack requiredLapisCost = EnchantmentCostRegistry.getServerRegistry().getLapisCost();
         ItemStack lapisSlotStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem();
@@ -89,9 +89,15 @@ public class ServerPayloadHandler {
                     packet.enchantmentLevel()
             );
 
-            tryGrantEnchantItemAdvancement(context);
+            player.awardStat(Stats.ENCHANT_ITEM);
 
-            if (packet.enchantmentLevel() == EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(ResourceLocation.parse(packet.enchantmentResourceId())).getHighestLevel()) {
+            if (player instanceof ServerPlayer serverPlayer) {
+                // Number is levels spent - using 1 to as a compatible default value
+                // (Adjust if optional enchantment cost extensions in the future may include xp cost)
+                CriteriaTriggers.ENCHANTED_ITEM.trigger(serverPlayer, itemToEnchant, 1);
+            }
+
+            if (packet.enchantmentLevel() == EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(packet.enchantment()).getHighestLevel()) {
                 //Sound FX for highest tier.
                 level.playSound(null, player.blockPosition(), SoundEvents.BEACON_POWER_SELECT,
                         SoundSource.BLOCKS, 1.0F, 1.0F);
@@ -118,10 +124,15 @@ public class ServerPayloadHandler {
      * @return
      */
     @Nullable
-    public static String getAncientBookResourceId(ItemStack book) {
+    public static ResourceKey<Enchantment> getAncientBookResourceKey(ItemStack book) {
         if (book.has(ModDataComponents.ENCHANTMENT)) {
-            return EnchantmentDataComponent.getEnchantmentData(book);
+            String resource = EnchantmentDataComponent.getEnchantmentData(book);
+
+            if (resource != null) {
+                return ResourceKey.create(Registries.ENCHANTMENT, ResourceLocation.parse(resource));
+            }
         }
+
         return null;
     }
 
@@ -134,15 +145,18 @@ public class ServerPayloadHandler {
     public static void checkBookshelvesAndUpdateClient(BlockPos tablePos, Level level, ServerPlayer serverPlayer) {
         List<BlockEntity> bookshelves = getChiseledBookshelvesNearby(tablePos, level);
 
-        //Store resource locations as strings - i.e "minecraft:respiration"
-        List<String> unlockedEnchantmentResourceIds = new ArrayList<>();
+        List<ResourceKey<Enchantment>> unlockedEnchantments = new ArrayList<>();
         for (BlockEntity bookshelf : bookshelves) {
             List<ItemStack> books = getChiseledBookshelfContents(bookshelf);
 
             //Get books in bookshelf
             for (ItemStack book : books) {
                 if (book.getItem() == ModItems.ANCIENT_BOOK.get()) {
-                    unlockedEnchantmentResourceIds.add(getAncientBookResourceId(book));
+                    ResourceKey<Enchantment> key = getAncientBookResourceKey(book);
+
+                    if (key != null) {
+                        unlockedEnchantments.add(key);
+                    }
                 }
             }
         }
@@ -150,20 +164,19 @@ public class ServerPayloadHandler {
         //Unlock all enchantments if creative bookshelf is near
         if(isCreativeBookshelfNearby(tablePos, level)) {
             //Clear unlockedEnchantments from the bookshelf search
-            unlockedEnchantmentResourceIds.clear();
+            unlockedEnchantments.clear();
 
             //Add all enchantments that exist
             RegistryAccess registryAccess = level.registryAccess();
             Registry<Enchantment> enchantmentRegistry = ImmersiveEnchanting.getEnchantmentRegistry(registryAccess);
             List<Holder.Reference<Enchantment>> allEnchantments = enchantmentRegistry.asLookup().listElements().toList();
 
-            // Convert each Holder to its ResourceLocation string
-            unlockedEnchantmentResourceIds = allEnchantments.stream()
-                    .map(holder -> holder.key().location().toString()) // returns "namespace:name"
+            unlockedEnchantments = allEnchantments.stream()
+                    .map(Holder.Reference::key)
                     .toList();
         }
 
-        PacketDistributor.sendToPlayer(serverPlayer, new UnlockedEnchantmentsPacket(unlockedEnchantmentResourceIds));
+        PacketDistributor.sendToPlayer(serverPlayer, new UnlockedEnchantmentsPacket(unlockedEnchantments));
     }
 
     /**
@@ -234,20 +247,6 @@ public class ServerPayloadHandler {
             }
         }
         return false;
-    }
-
-    /**
-     * Try to grant the enchant item advancement.
-     */
-    private static void tryGrantEnchantItemAdvancement(IPayloadContext context) {
-        AdvancementHolder advancement = context.player().getServer().getAdvancements().get(
-                ResourceLocation.fromNamespaceAndPath(
-                        "minecraft", "story/enchant_item"
-                ));
-        System.out.println(advancement);
-        context.player().getServer().getPlayerList()
-                .getPlayerAdvancements((ServerPlayer) context.player())
-                .award(advancement, "enchanted_item");
     }
 }
 

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
@@ -69,7 +69,8 @@ public class ServerPayloadHandler {
         ItemStack requiredLapisCost = EnchantmentCostRegistry.getServerRegistry().getLapisCost();
         ItemStack lapisSlotStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem();
 
-        boolean hasEnoughCost = (requiredLapisCost.isEmpty() ||
+        boolean hasEnoughCost = player.hasInfiniteMaterials() ||
+                (requiredLapisCost.isEmpty() ||
                 (lapisSlotStack.is(requiredLapisCost.getItem()) && lapisSlotStack.getCount() >= requiredLapisCost.getCount()))
                 && (requiredItemCostStack.isEmpty() ||
                 (costSlotItemStack.is(requiredItemCostStack.getItem()) &&
@@ -77,10 +78,12 @@ public class ServerPayloadHandler {
 
 
         if (hasEnoughCost) {
-            enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem()
-                    .shrink(requiredLapisCost.getCount()); //Use enchantmnet cost registry
-            if(!requiredItemCostStack.isEmpty()) {
-                costSlotItemStack.shrink(requiredItemCostStack.getCount()); //Use enchantment cost if not air
+            if (!player.hasInfiniteMaterials()) {
+                enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem()
+                        .shrink(requiredLapisCost.getCount()); //Use enchantmnet cost registry
+                if (!requiredItemCostStack.isEmpty()) {
+                    costSlotItemStack.shrink(requiredItemCostStack.getCount()); //Use enchantment cost if not air
+                }
             }
 
             //Enchant item server side

--- a/src/main/java/me/alfie/immersiveenchanting/networking/packets/EnchantItemPacket.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/packets/EnchantItemPacket.java
@@ -2,20 +2,24 @@ package me.alfie.immersiveenchanting.networking.packets;
 
 import io.netty.buffer.ByteBuf;
 import me.alfie.immersiveenchanting.networking.ServerPayloadHandler;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.handling.DirectionalPayloadHandler;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 
-public record EnchantItemPacket(String enchantmentResourceId, int enchantmentLevel) implements CustomPacketPayload {
+public record EnchantItemPacket(ResourceKey<Enchantment> enchantment, int enchantmentLevel) implements CustomPacketPayload {
     public static final CustomPacketPayload.Type<EnchantItemPacket> TYPE = new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath("immersiveenchanting", "enchantmentpacket"));
 
-    public static final StreamCodec<ByteBuf, EnchantItemPacket> STREAM_CODEC = StreamCodec.composite(
-            ByteBufCodecs.STRING_UTF8,
-            EnchantItemPacket::enchantmentResourceId,
+    public static final StreamCodec<RegistryFriendlyByteBuf, EnchantItemPacket> STREAM_CODEC = StreamCodec.composite(
+            ResourceKey.streamCodec(Registries.ENCHANTMENT),
+            EnchantItemPacket::enchantment,
             ByteBufCodecs.VAR_INT,
             EnchantItemPacket::enchantmentLevel,
             EnchantItemPacket::new

--- a/src/main/java/me/alfie/immersiveenchanting/networking/packets/EnchantmentCostRegistrySyncPacket.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/packets/EnchantmentCostRegistrySyncPacket.java
@@ -1,17 +1,19 @@
 package me.alfie.immersiveenchanting.networking.packets;
 
 import io.netty.buffer.ByteBuf;
-import me.alfie.immersiveenchanting.ImmersiveEnchanting;
 import me.alfie.immersiveenchanting.datapack.EnchantmentCost;
 import me.alfie.immersiveenchanting.datapack.EnchantmentCostRegistry;
 import me.alfie.immersiveenchanting.datapack.LevelCost;
 import me.alfie.immersiveenchanting.networking.ClientPayloadHandler;
 import me.alfie.immersiveenchanting.networking.SerializedEnchantmentCostRegistry;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.neoforged.neoforge.network.PacketDistributor;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.handling.DirectionalPayloadHandler;
@@ -71,8 +73,8 @@ public record EnchantmentCostRegistrySyncPacket(
         List<Integer> amounts = new ArrayList<>();
 
         //For each entry in the EnchantmentCostRegistry
-        for(Map.Entry<ResourceLocation, EnchantmentCost> registryEntry : costRegistry.getCostRegistry().entrySet()) {
-            ResourceLocation enchantmentResourceLocation = registryEntry.getKey();
+        for(Map.Entry<ResourceKey<Enchantment>, EnchantmentCost> registryEntry : costRegistry.getCostRegistry().entrySet()) {
+            ResourceKey<Enchantment> enchantmentKey = registryEntry.getKey();
             EnchantmentCost cost = registryEntry.getValue();
 
             //For each entry in the EnchantmentCost
@@ -83,7 +85,7 @@ public record EnchantmentCostRegistrySyncPacket(
                 int amount = levelCost.amount();
 
                 //Add data to form parallel lists
-                enchantmentNamespaces.add(enchantmentResourceLocation.toString());
+                enchantmentNamespaces.add(enchantmentKey.location().toString());
                 levels.add(level);
                 itemNamespaces.add(itemNamespace);
                 amounts.add(amount);
@@ -115,7 +117,8 @@ public record EnchantmentCostRegistrySyncPacket(
             LevelCost levelCost = new LevelCost(item, amount);
             //Build EnchantmentCost
             //Only create a new enchantment cost instance if it doesn't exist yet
-            EnchantmentCost enchantmentCost = enchantmentCostRegistry.getCostRegistry().computeIfAbsent(enchantmentResourceLocation, k -> new EnchantmentCost());
+            EnchantmentCost enchantmentCost = enchantmentCostRegistry.getCostRegistry()
+                    .computeIfAbsent(ResourceKey.create(Registries.ENCHANTMENT, enchantmentResourceLocation),k -> new EnchantmentCost());
             enchantmentCost.levels.put(level, levelCost);
         }
 

--- a/src/main/java/me/alfie/immersiveenchanting/networking/packets/UnlockedEnchantmentsPacket.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/packets/UnlockedEnchantmentsPacket.java
@@ -2,10 +2,14 @@ package me.alfie.immersiveenchanting.networking.packets;
 
 import io.netty.buffer.ByteBuf;
 import me.alfie.immersiveenchanting.networking.ClientPayloadHandler;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.enchantment.Enchantment;
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.handling.DirectionalPayloadHandler;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
@@ -13,11 +17,11 @@ import net.neoforged.neoforge.network.registration.PayloadRegistrar;
 import java.util.ArrayList;
 import java.util.List;
 
-public record UnlockedEnchantmentsPacket(List<String> enchantments) implements CustomPacketPayload {
+public record UnlockedEnchantmentsPacket(List<ResourceKey<Enchantment>> enchantments) implements CustomPacketPayload {
     public static final Type<UnlockedEnchantmentsPacket> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath("immersiveenchanting", "unlockedenchantmentpacket"));
 
-    public static final StreamCodec<ByteBuf, UnlockedEnchantmentsPacket> STREAM_CODEC = StreamCodec.composite(
-            ByteBufCodecs.collection(ArrayList::new, ByteBufCodecs.STRING_UTF8),
+    public static final StreamCodec<RegistryFriendlyByteBuf, UnlockedEnchantmentsPacket> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.collection(ArrayList::new, ResourceKey.streamCodec(Registries.ENCHANTMENT)),
             UnlockedEnchantmentsPacket::enchantments,
             UnlockedEnchantmentsPacket::new
     );


### PR DESCRIPTION
+ award enchant item stats
+ trigger advancement criteria instead of granting advancement
+ skip lapis / item cost in creative mode

---

resource keys are faster to compare since there should only be 1 java object per entry
(entries being tracked inside a value map within the resourcekey class)