### PR TITLE
Jade compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ dependencies {
     /* --- Compatibility --- */
     compileOnly "curse.maven:enchant-limiter-1235635:7152638" // 1.0.8
     compileOnly "curse.maven:enchantment-descriptions-250419:7039849" // 21.1.9
+    compileOnly "curse.maven:jade-324717:6853386" // 15.10.3
 }
 
 // This block of code expands all declared replace properties in the specified resource targets.

--- a/src/main/java/me/alfie/immersiveenchanting/compat/ModCheck.java
+++ b/src/main/java/me/alfie/immersiveenchanting/compat/ModCheck.java
@@ -19,7 +19,7 @@ public class ModCheck {
      * @param modid
      * @return
      */
-    private static boolean isModLoaded(final String modid) {
+    public static boolean isModLoaded(final String modid) {
         return MODS.computeIfAbsent(modid, key -> {
             if (check(key)) {
                 return true;

--- a/src/main/java/me/alfie/immersiveenchanting/item/AncientBook.java
+++ b/src/main/java/me/alfie/immersiveenchanting/item/AncientBook.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class AncientBook extends Item {
-
+    public static final String TRANSLATION_KEY = "lore.immersiveenchanting.ancient_book";
 
     public AncientBook(Properties properties) {
         super(properties.stacksTo(1).rarity(Rarity.UNCOMMON));
@@ -62,7 +62,7 @@ public class AncientBook extends Item {
             Optional<Holder.Reference<Enchantment>> enchantmentHolder = ImmersiveEnchanting.getEnchantmentHolder(registryAccess, enchantmentResourceKey);
 
             //Translation key for lore text.
-            MutableComponent loreText = Component.translatable("lore.immersiveenchanting.ancient_book");
+            MutableComponent loreText = Component.translatable(TRANSLATION_KEY);
 
             //Enchantment name (styled)
             MutableComponent enchantName = (MutableComponent) enchantment.description();

--- a/src/main/java/me/alfie/immersiveenchanting/mixins/ApplyMixinPlugin.java
+++ b/src/main/java/me/alfie/immersiveenchanting/mixins/ApplyMixinPlugin.java
@@ -1,0 +1,51 @@
+package me.alfie.immersiveenchanting.mixins;
+
+import me.alfie.immersiveenchanting.compat.ModCheck;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.List;
+import java.util.Set;
+
+public class ApplyMixinPlugin implements IMixinConfigPlugin {
+    private final static String PREFIX = ApplyMixinPlugin.class.getPackageName() + ".";
+
+    @Override
+    public void onLoad(final String mixinPackage) {  /* Nothing to do */ }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(final String targetClassName, final String mixinClassName) {
+        String directory = mixinClassName.replace(PREFIX, "");
+        // Remove directories which are not related to mods (client e.g., for client-related mixins)
+        directory = directory.replace("client.", "");
+        // If a directory is still present, it will run through the check below
+        String[] elements = directory.split("\\.");
+
+        if (elements.length == 2) {
+            String modid = elements[0];
+            return ModCheck.isModLoaded(modid);
+        }
+
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(final Set<String> myTargets, final Set<String> otherTargets) { /* Nothing to do */ }
+
+    @Override
+    public List<String> getMixins() {
+        return null;
+    }
+
+    @Override
+    public void preApply(final String targetClassName, final ClassNode targetClass, final String mixinClassName, final IMixinInfo mixinInfo) { /* Nothing to do */ }
+
+    @Override
+    public void postApply(final String targetClassName, final ClassNode targetClass, final String mixinClassName, final IMixinInfo mixinInfo) { /* Nothing to do */ }
+}

--- a/src/main/java/me/alfie/immersiveenchanting/mixins/jade/ChiseledBookshelfProviderMixin.java
+++ b/src/main/java/me/alfie/immersiveenchanting/mixins/jade/ChiseledBookshelfProviderMixin.java
@@ -1,0 +1,50 @@
+package me.alfie.immersiveenchanting.mixins.jade;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import me.alfie.immersiveenchanting.datacomponents.EnchantmentDataComponent;
+import me.alfie.immersiveenchanting.datacomponents.ModDataComponents;
+import me.alfie.immersiveenchanting.item.AncientBook;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import snownee.jade.addon.vanilla.ChiseledBookshelfProvider;
+import snownee.jade.api.BlockAccessor;
+import snownee.jade.api.ITooltip;
+import snownee.jade.api.config.IPluginConfig;
+
+@Mixin(ChiseledBookshelfProvider.class)
+public abstract class ChiseledBookshelfProviderMixin {
+    @Inject(method = "appendTooltip(Lsnownee/jade/api/ITooltip;Lsnownee/jade/api/BlockAccessor;Lsnownee/jade/api/config/IPluginConfig;)V", at = @At("TAIL"))
+    private void immersiveenchanting$addTooltip(final ITooltip tooltip, final BlockAccessor accessor, final IPluginConfig config, final CallbackInfo callback, @Local(name = "item") final ItemStack stack) {
+        if (stack.isEmpty()) {
+            return;
+        }
+
+        EnchantmentDataComponent enchantmentData = stack.get(ModDataComponents.ENCHANTMENT);
+
+        if (enchantmentData == null) {
+            return;
+        }
+
+        String resource = enchantmentData.enchantmentResourceLocation();
+
+        if (resource == null) {
+            return;
+        }
+
+        accessor.getLevel().registryAccess().registryOrThrow(Registries.ENCHANTMENT)
+                .getHolder(ResourceLocation.parse(resource))
+                .ifPresent(enchantment -> tooltip.add(
+                        Component.translatable(AncientBook.TRANSLATION_KEY)
+                                .withStyle(ChatFormatting.GOLD)
+                                .append(" ")
+                                .append(enchantment.value().description())
+                ));
+    }
+}

--- a/src/main/resources/immersiveenchanting.mixins.json
+++ b/src/main/resources/immersiveenchanting.mixins.json
@@ -1,0 +1,18 @@
+{
+  "required": true,
+  "minVersion": "0.8",
+  "package": "me.alfie.immersiveenchanting.mixins",
+  "compatibilityLevel": "JAVA_21",
+  "plugin": "me.alfie.immersiveenchanting.mixins.ApplyMixinPlugin",
+  "mixins": [
+    "jade.ChiseledBookshelfProviderMixin"
+  ],
+  "client": [
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  },
+  "overwrites": {
+    "requireAnnotations": true
+  }
+}

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -52,8 +52,8 @@ credits = '''Thanks to @carl_classic on Modrinth for the Enchanted Book sprites!
 Thanks to everyone in The NeoForge Project Discord.'''
 
 # The [[mixins]] block allows you to declare your mixin config to FML so that it gets loaded.
-#[[mixins]]
-#config="${mod_id}.mixins.json"
+[[mixins]]
+config="${mod_id}.mixins.json"
 
 # The [[accessTransformers]] block allows you to declare where your AT file is.
 # If this block is omitted, a fallback attempt will be made to load an AT from META-INF/accesstransformer.cfg


### PR DESCRIPTION
I think there would also be the option to add your own plugin for the same block (chiseled bookshelf)

But personally I think it's clearer to the end-user if they only have to interact with one plugin that they can enable / disable instead of multiple

<img width="944" height="952" alt="image" src="https://github.com/user-attachments/assets/2f4068ee-d3ea-4752-acda-3e01a4224edd" />