### PR TITLE
Forge 1.20.1

### DIFF
--- a/src/main/java/me/alfie/immersiveenchanting/ImmersiveEnchanting.java
+++ b/src/main/java/me/alfie/immersiveenchanting/ImmersiveEnchanting.java
@@ -50,7 +50,7 @@ public class ImmersiveEnchanting {
         ModBlocks.register(modEventBus);
 
         context.registerConfig(ModConfig.Type.CLIENT, ClientConfig.CONFIG_SPEC);
-        context.registerConfig(ModConfig.Type.SERVER, ServerConfig.CONFIG_SPEC);
+        context.registerConfig(ModConfig.Type.COMMON, ServerConfig.CONFIG_SPEC);
     }
 
     public static HolderLookup<Enchantment> getEnchantmentHolderLookup(RegistryAccess access) {

--- a/src/main/java/me/alfie/immersiveenchanting/config/ServerConfig.java
+++ b/src/main/java/me/alfie/immersiveenchanting/config/ServerConfig.java
@@ -52,6 +52,8 @@ public class ServerConfig {
 
         bookUnlockMode = builder
                 .comment("Controls how many enchantment levels are unlocked when a book is placed in a nearby chiseled bookshelf.\n" +
+                        "  Note: This setting only has a meaningful effect when vanillaBookMode is enabled, since vanilla enchanted books carry level information.\n" +
+                        "  With Ancient Books (vanillaBookMode = false), all modes behave the same as mode 2, as Ancient Books carry no level information.\n" +
                         "  0 = Restrictive: only the exact level of the book is unlocked (e.g. Efficiency III unlocks only level 3).\n" +
                         "  1 = Default: all levels up to and including the book's level are unlocked (e.g. Efficiency III unlocks levels 1, 2, and 3).\n" +
                         "  2 = Permissive: all levels of the enchantment are unlocked regardless of the book's level (e.g. Efficiency III unlocks all Efficiency levels).")

--- a/src/main/java/me/alfie/immersiveenchanting/config/ServerConfig.java
+++ b/src/main/java/me/alfie/immersiveenchanting/config/ServerConfig.java
@@ -11,6 +11,7 @@ public class ServerConfig {
     // Store the config properties as public finals
     public final ForgeConfigSpec.ConfigValue<Boolean> disableAncientBookRequirement;
     public final ForgeConfigSpec.ConfigValue<Integer> bookshelfSearchHeight;
+    public final ForgeConfigSpec.ConfigValue<Boolean> vanillaBookMode;
 
 
 
@@ -37,6 +38,10 @@ public class ServerConfig {
                 .translation("immersiveenchanting.config.bookshelf_search_height") // translatable label
                 .defineInRange("bookshelfSearchHeight", 3, 1, 5);
 
+        vanillaBookMode = builder
+                .comment("If enabled, Ancient Books are replaced by regular enchanted books. Loot pools are not modified, and regular enchanted books can be placed in chiseled bookshelves to unlock enchantments at the enchanting table.")
+                .translation("immersiveenchanting.config.vanilla_book_mode")
+                .define("vanillaBookMode", false);
 
         builder.pop();
     }
@@ -51,5 +56,9 @@ public class ServerConfig {
 
     public static int getBookshelfSearchHeight() {
         return ServerConfig.CONFIG.bookshelfSearchHeight.get();
+    }
+
+    public static boolean isVanillaBookModeEnabled() {
+        return ServerConfig.CONFIG.vanillaBookMode.get();
     }
 }

--- a/src/main/java/me/alfie/immersiveenchanting/config/ServerConfig.java
+++ b/src/main/java/me/alfie/immersiveenchanting/config/ServerConfig.java
@@ -13,6 +13,7 @@ public class ServerConfig {
     public final ForgeConfigSpec.ConfigValue<Integer> bookshelfSearchHeight;
     public final ForgeConfigSpec.ConfigValue<Boolean> vanillaBookMode;
     public final ForgeConfigSpec.ConfigValue<Boolean> xpCostMode;
+    public final ForgeConfigSpec.ConfigValue<Integer> bookUnlockMode;
 
 
 
@@ -49,6 +50,14 @@ public class ServerConfig {
                 .translation("immersiveenchanting.config.xp_cost_mode")
                 .define("xpCostMode", false);
 
+        bookUnlockMode = builder
+                .comment("Controls how many enchantment levels are unlocked when a book is placed in a nearby chiseled bookshelf.\n" +
+                        "  0 = Restrictive: only the exact level of the book is unlocked (e.g. Efficiency III unlocks only level 3).\n" +
+                        "  1 = Default: all levels up to and including the book's level are unlocked (e.g. Efficiency III unlocks levels 1, 2, and 3).\n" +
+                        "  2 = Permissive: all levels of the enchantment are unlocked regardless of the book's level (e.g. Efficiency III unlocks all Efficiency levels).")
+                .translation("immersiveenchanting.config.book_unlock_mode")
+                .defineInRange("bookUnlockMode", 1, 0, 2);
+
         builder.pop();
     }
 
@@ -70,5 +79,9 @@ public class ServerConfig {
 
     public static boolean isXpCostModeEnabled() {
         return ServerConfig.CONFIG.xpCostMode.get();
+    }
+
+    public static int getBookUnlockMode() {
+        return ServerConfig.CONFIG.bookUnlockMode.get();
     }
 }

--- a/src/main/java/me/alfie/immersiveenchanting/config/ServerConfig.java
+++ b/src/main/java/me/alfie/immersiveenchanting/config/ServerConfig.java
@@ -12,6 +12,7 @@ public class ServerConfig {
     public final ForgeConfigSpec.ConfigValue<Boolean> disableAncientBookRequirement;
     public final ForgeConfigSpec.ConfigValue<Integer> bookshelfSearchHeight;
     public final ForgeConfigSpec.ConfigValue<Boolean> vanillaBookMode;
+    public final ForgeConfigSpec.ConfigValue<Boolean> xpCostMode;
 
 
 
@@ -43,6 +44,11 @@ public class ServerConfig {
                 .translation("immersiveenchanting.config.vanilla_book_mode")
                 .define("vanillaBookMode", false);
 
+        xpCostMode = builder
+                .comment("If enabled, enchanting costs XP levels instead of materials. Each enchantment level costs (level * 3) XP levels (e.g. level 1 = 3 levels, level 2 = 6 levels, level 3 = 9 levels). Material costs from datapacks are ignored.")
+                .translation("immersiveenchanting.config.xp_cost_mode")
+                .define("xpCostMode", false);
+
         builder.pop();
     }
 
@@ -60,5 +66,9 @@ public class ServerConfig {
 
     public static boolean isVanillaBookModeEnabled() {
         return ServerConfig.CONFIG.vanillaBookMode.get();
+    }
+
+    public static boolean isXpCostModeEnabled() {
+        return ServerConfig.CONFIG.xpCostMode.get();
     }
 }

--- a/src/main/java/me/alfie/immersiveenchanting/datapack/EnchantmentCostRegistry.java
+++ b/src/main/java/me/alfie/immersiveenchanting/datapack/EnchantmentCostRegistry.java
@@ -16,6 +16,7 @@ public class EnchantmentCostRegistry {
     // Maps the enchantment ResourceLocation (e.g., minecraft:efficiency) to its cost data
     private final Map<ResourceKey<Enchantment>, EnchantmentCost> COST_REGISTRY = new HashMap<>();
     private ItemStack lapisCost;
+    private boolean xpCostMode = false;
 
     public static EnchantmentCostRegistry getClientRegistry() {
         return clientEnchantmentCostRegistry;
@@ -90,5 +91,13 @@ public class EnchantmentCostRegistry {
 
     public void setLapisCost(ItemStack lapisCost) {
         this.lapisCost = lapisCost;
+    }
+
+    public boolean isXpCostMode() {
+        return xpCostMode;
+    }
+
+    public void setXpCostMode(boolean xpCostMode) {
+        this.xpCostMode = xpCostMode;
     }
 }

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeBranch.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeBranch.java
@@ -28,6 +28,7 @@ public class EnchantingNodeBranch {
     private final Holder<Enchantment> enchantmentHolder;
     private final int equippedLevel;
     private final boolean isBranchUnlocked;
+    private final int maxUnlockedLevel;
     private final Player player;
     private final List<Pixel> precomputedPixels = new ArrayList<>();
     ResourceLocation bakedTextureLocation;
@@ -40,12 +41,14 @@ public class EnchantingNodeBranch {
     public EnchantingNodeBranch(EnchantingTableScreen screen, float branchAngle,
                                 Holder<Enchantment> enchantmentHolder, int equippedLevel,
                                 boolean isBranchUnlocked,
+                                int maxUnlockedLevel,
                                 Player player) {
         this.screen = screen;
         this.branchAngle = branchAngle;
         this.enchantmentHolder = enchantmentHolder;
         this.equippedLevel = equippedLevel; //0 if not enchantment not equipped.
         this.isBranchUnlocked = isBranchUnlocked;
+        this.maxUnlockedLevel = maxUnlockedLevel;
         this.player = player;
 
         //ResourceLocation icon_texture = enchantmentType.getIconTexture();
@@ -81,12 +84,17 @@ public class EnchantingNodeBranch {
                     ? EnchantingNodeType.ELITE
                     : EnchantingNodeType.BASIC;
 
+            // Node is individually unlocked only if the branch is unlocked AND
+            // this level falls within the max unlocked level from the bookshelf.
+            boolean isNodeUnlocked = this.isBranchUnlocked &&
+                    (maxUnlockedLevel == Integer.MAX_VALUE || i <= maxUnlockedLevel);
+
             EnchantingNode node = new EnchantingNode(
                     nodeType,
                     icon_texture,
                     i,
                     enchantmentHolder,
-                    this.isBranchUnlocked
+                    isNodeUnlocked
             );
 
             if (i <= equippedLevel) {

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeTooltip.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeTooltip.java
@@ -1,6 +1,7 @@
 package me.alfie.immersiveenchanting.gui;
 
 import me.alfie.immersiveenchanting.ImmersiveEnchanting;
+import me.alfie.immersiveenchanting.datapack.EnchantmentCostRegistry;
 import net.minecraft.ChatFormatting;
 import net.minecraft.client.gui.Font;
 import net.minecraft.client.gui.GuiGraphics;
@@ -174,7 +175,15 @@ public class EnchantingNodeTooltip {
                     ChatFormatting.GREEN.getColor());
 
             if (!node.isObtained()) {
-                if (costStack.is(Items.AIR) || costStack.isEmpty()) {
+                if (EnchantmentCostRegistry.getClientRegistry().isXpCostMode()) {
+                    int xpLevels = node.getEnchantmentLevel() * 3;
+                    String xpText = xpLevels + " XP levels";
+                    graphics.drawString(font,
+                            xpText,
+                            descriptionBoxTopLeft.x + costBoxLabelX + padding,
+                            costBoxLabelY + padding / 2,
+                            0x80FF20); // XP bar green
+                } else if (costStack.is(Items.AIR) || costStack.isEmpty()) {
                     graphics.drawString(font,
                             Component.translatable("gui.immersiveenchanting.cost_free"),
                             descriptionBoxTopLeft.x + costBoxLabelX + padding,

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeTooltip.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeTooltip.java
@@ -178,11 +178,19 @@ public class EnchantingNodeTooltip {
                 if (EnchantmentCostRegistry.getClientRegistry().isXpCostMode()) {
                     int xpLevels = node.getEnchantmentLevel() * 3;
                     String xpText = xpLevels + " XP levels";
+                    int xpTextX = descriptionBoxTopLeft.x + costBoxLabelX + padding;
                     graphics.drawString(font,
                             xpText,
-                            descriptionBoxTopLeft.x + costBoxLabelX + padding,
+                            xpTextX,
                             costBoxLabelY + padding / 2,
                             0x80FF20); // XP bar green
+                    // Also show lapis cost icon if lapis is required
+                    ItemStack lapisCost = EnchantmentCostRegistry.getClientRegistry().getLapisCost();
+                    if (!lapisCost.isEmpty()) {
+                        costStackPos = new Vector2i(xpTextX + font.width(xpText) + 2, costBoxLabelY);
+                        graphics.renderItem(lapisCost, costStackPos.x, costStackPos.y);
+                        graphics.renderItemDecorations(font, lapisCost, costStackPos.x, costStackPos.y);
+                    }
                 } else if (costStack.is(Items.AIR) || costStack.isEmpty()) {
                     graphics.drawString(font,
                             Component.translatable("gui.immersiveenchanting.cost_free"),

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeTooltip.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingNodeTooltip.java
@@ -176,7 +176,8 @@ public class EnchantingNodeTooltip {
 
             if (!node.isObtained()) {
                 if (EnchantmentCostRegistry.getClientRegistry().isXpCostMode()) {
-                    int xpLevels = node.getEnchantmentLevel() * 3;
+                    int effectiveLevel = (node.getEnchantmentHolder().get().getMaxLevel() == 1) ? 3 : node.getEnchantmentLevel();
+                    int xpLevels = effectiveLevel * 3;
                     String xpText = xpLevels + " XP levels";
                     int xpTextX = descriptionBoxTopLeft.x + costBoxLabelX + padding;
                     graphics.drawString(font,

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingTableMenu.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingTableMenu.java
@@ -17,7 +17,9 @@ import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 import net.minecraftforge.items.SlotItemHandler;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class EnchantingTableMenu extends AbstractContainerMenu {
@@ -26,7 +28,8 @@ public class EnchantingTableMenu extends AbstractContainerMenu {
     private ContainerLevelAccess access;
     private Level level;
     private IItemHandler containerInventory;
-    private Set<Holder<Enchantment>> unlockedEnchantments = new HashSet<>();
+    /** Maps each unlocked enchantment to its max unlocked level. Integer.MAX_VALUE means all levels. */
+    private Map<Holder<Enchantment>, Integer> unlockedEnchantments = new HashMap<>();
 
 
     //My constructor
@@ -152,11 +155,11 @@ public class EnchantingTableMenu extends AbstractContainerMenu {
         return AbstractContainerMenu.stillValid(this.access, player, Blocks.ENCHANTING_TABLE);
     }
 
-    public Set<Holder<Enchantment>> getUnlockedEnchantments() {
+    public Map<Holder<Enchantment>, Integer> getUnlockedEnchantments() {
         return unlockedEnchantments;
     }
 
-    public void setUnlockedEnchantments(Set<Holder<Enchantment>> unlockedEnchantments) {
+    public void setUnlockedEnchantments(Map<Holder<Enchantment>, Integer> unlockedEnchantments) {
         this.unlockedEnchantments = unlockedEnchantments;
     }
 

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingTableScreen.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingTableScreen.java
@@ -24,8 +24,8 @@ import org.joml.Vector2i;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 public class EnchantingTableScreen extends AbstractContainerScreen<EnchantingTableMenu> {
@@ -165,7 +165,7 @@ public class EnchantingTableScreen extends AbstractContainerScreen<EnchantingTab
     public void buildNodeBranches(ItemStack currentItemStack) {
         //Step 1. Find which enchantments are applicable.
         Set<Holder<Enchantment>> validEnchantments = new HashSet<>(); //Set of all enchantments that can be applied
-        Set<Holder<Enchantment>> unlockedEnchantments = menu.getUnlockedEnchantments();
+        Map<Holder<Enchantment>, Integer> unlockedEnchantments = menu.getUnlockedEnchantments();
 
         Set<Holder<Enchantment>> allEnchantments = ImmersiveEnchanting.getEnchantmentRegistry(
                         player.level().registryAccess())
@@ -210,19 +210,20 @@ public class EnchantingTableScreen extends AbstractContainerScreen<EnchantingTab
 
         int i = 0;
         for (Holder<Enchantment> enchantmentHolder : validEnchantments) {
-            //Check if the enchantmentResourceId is unlocked.
-            boolean isUnlocked = unlockedEnchantments.contains(enchantmentHolder);
-            AtomicInteger enchantmentLevel = new AtomicInteger();
+            // -1 means not unlocked at all; Integer.MAX_VALUE means all levels unlocked
+            int maxUnlockedLevel = unlockedEnchantments.getOrDefault(enchantmentHolder, -1);
+            boolean isUnlocked = maxUnlockedLevel >= 0;
 
-            //Get the level of this enchantment
-            enchantmentLevel.set(currentItemStack.getItem().getEnchantmentLevel(currentItemStack, enchantmentHolder.get()));
+            //Get the level of this enchantment already on the item
+            int enchantmentLevel = currentItemStack.getItem().getEnchantmentLevel(currentItemStack, enchantmentHolder.get());
 
             branches.add(new EnchantingNodeBranch(
                     this,
                     angles.get(i),
                     enchantmentHolder,
-                    enchantmentLevel.get(),
+                    enchantmentLevel,
                     isUnlocked,
+                    maxUnlockedLevel,
                     player
             ));
             i++;

--- a/src/main/java/me/alfie/immersiveenchanting/lootmodifier/AncientBookLootModifier.java
+++ b/src/main/java/me/alfie/immersiveenchanting/lootmodifier/AncientBookLootModifier.java
@@ -3,6 +3,7 @@ package me.alfie.immersiveenchanting.lootmodifier;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import me.alfie.immersiveenchanting.config.ServerConfig;
 import me.alfie.immersiveenchanting.datapack.EnchantmentCostRegistry;
 import me.alfie.immersiveenchanting.datapack.LevelCost;
 import me.alfie.immersiveenchanting.item.AncientBook;
@@ -64,6 +65,7 @@ public class AncientBookLootModifier extends LootModifier {
      */
     @Override
     protected ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
+        if (ServerConfig.isVanillaBookModeEnabled()) return generatedLoot;
         if (context.getRandom().nextFloat() < chance) { // chance from JSON
             ItemStack lootItem = new ItemStack(item, count);
 

--- a/src/main/java/me/alfie/immersiveenchanting/lootmodifier/RemoveEnchantedBooksModifier.java
+++ b/src/main/java/me/alfie/immersiveenchanting/lootmodifier/RemoveEnchantedBooksModifier.java
@@ -3,6 +3,7 @@ package me.alfie.immersiveenchanting.lootmodifier;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import me.alfie.immersiveenchanting.config.ServerConfig;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import net.minecraft.world.level.storage.loot.LootContext;
@@ -38,6 +39,7 @@ public class RemoveEnchantedBooksModifier extends LootModifier {
      */
     @Override
     protected ObjectArrayList<ItemStack> doApply(ObjectArrayList<ItemStack> generatedLoot, LootContext context) {
+        if (ServerConfig.isVanillaBookModeEnabled()) return generatedLoot;
         generatedLoot.removeIf(stack -> stack.getItem() == Items.ENCHANTED_BOOK);
         return generatedLoot;
     }

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ClientPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ClientPayloadHandler.java
@@ -41,7 +41,7 @@ public class ClientPayloadHandler {
         );
 
         EnchantmentCostRegistry.setClientRegistry(
-                EnchantmentCostRegistrySyncPacket.deserialize(serializedRegistry)
+                EnchantmentCostRegistrySyncPacket.deserialize(serializedRegistry, packet.xpCostMode)
         );
     }
 

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ClientPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ClientPayloadHandler.java
@@ -14,8 +14,8 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Server -> Client
@@ -52,15 +52,15 @@ public class ClientPayloadHandler {
      * @param context
      */
     public static void onUnlockedEnchantments(final UnlockedEnchantmentsPacket packet, final NetworkEvent.Context context) {
-        Set<ResourceKey<Enchantment>> unlockedEnchantmentResourceIds = new HashSet<>(packet.enchantments);
         LocalPlayer player = Minecraft.getInstance().player;
 
-        Set<Holder<Enchantment>> unlockedEnchantments = new HashSet<>();
-        for (ResourceKey<Enchantment> enchantmentKey : unlockedEnchantmentResourceIds) {
+        Map<Holder<Enchantment>, Integer> unlockedEnchantments = new HashMap<>();
+        for (int i = 0; i < packet.enchantments.size(); i++) {
+            ResourceKey<Enchantment> enchantmentKey = packet.enchantments.get(i);
+            int maxLevel = packet.maxLevels.get(i);
             ImmersiveEnchanting.getEnchantmentHolder(player.level().registryAccess(), enchantmentKey)
-                    .ifPresent(unlockedEnchantments::add);
+                    .ifPresent(holder -> unlockedEnchantments.put(holder, maxLevel));
         }
-
 
         if (player.containerMenu instanceof EnchantingTableMenu menu) {
             menu.setUnlockedEnchantments(unlockedEnchantments);

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
@@ -16,7 +16,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.RegistryAccess;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
@@ -24,6 +28,7 @@ import net.minecraft.stats.Stats;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.EnchantedBookItem;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
@@ -161,6 +166,16 @@ public class ServerPayloadHandler {
 
                     if (key != null) {
                         unlockedEnchantments.add(key);
+                    }
+                } else if (ServerConfig.isVanillaBookModeEnabled() && book.getItem() instanceof EnchantedBookItem) {
+                    ListTag storedEnchantments = EnchantedBookItem.getEnchantments(book);
+                    for (int i = 0; i < storedEnchantments.size(); i++) {
+                        CompoundTag tag = storedEnchantments.getCompound(i);
+                        ResourceLocation enchantmentRL = ResourceLocation.tryParse(tag.getString("id"));
+                        if (enchantmentRL != null) {
+                            ResourceKey<Enchantment> key = ResourceKey.create(Registries.ENCHANTMENT, enchantmentRL);
+                            unlockedEnchantments.add(key);
+                        }
                     }
                 }
             }

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
@@ -188,8 +188,14 @@ public class ServerPayloadHandler {
                 if (book.getItem() == ModItems.ANCIENT_BOOK.get()) {
                     ResourceKey<Enchantment> key = AncientBook.getEnchantment(book, level);
                     if (key != null) {
-                        // Ancient books have no level concept - treat as level 1
-                        highestFoundLevel.merge(key, 1, Math::max);
+                        // Ancient books have no level concept - use the enchantment's full max level
+                        // so that bookUnlockMode still behaves correctly (modes 0/1 would otherwise
+                        // always cap at level 1, making higher levels permanently inaccessible).
+                        RegistryAccess registryAccess = level.registryAccess();
+                        Registry<Enchantment> enchantmentRegistry = ImmersiveEnchanting.getEnchantmentRegistry(registryAccess);
+                        Enchantment enchantment = enchantmentRegistry.get(key);
+                        int maxLevel = (enchantment != null) ? enchantment.getMaxLevel() : 1;
+                        highestFoundLevel.merge(key, maxLevel, Math::max);
                     }
                 } else if (ServerConfig.isVanillaBookModeEnabled() && book.getItem() instanceof EnchantedBookItem) {
                     ListTag storedEnchantments = EnchantedBookItem.getEnchantments(book);

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
@@ -70,26 +70,39 @@ public class ServerPayloadHandler {
         );
 
         //Check enchantment cost
-        ItemStack costSlotItemStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.COST.ordinal()).getItem();
-        ItemStack requiredItemCostStack = EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(packet.enchantment).getLevel(packet.enchantmentLevel).asItemStack();
+        final int xpLevelCost = packet.enchantmentLevel * 3;
+        boolean hasEnoughCost;
 
-        ItemStack requiredLapisCost = EnchantmentCostRegistry.getServerRegistry().getLapisCost();
-        ItemStack lapisSlotStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem();
+        if (ServerConfig.isXpCostModeEnabled()) {
+            hasEnoughCost = player.isCreative() || player.experienceLevel >= xpLevelCost;
+        } else {
+            ItemStack costSlotItemStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.COST.ordinal()).getItem();
+            ItemStack requiredItemCostStack = EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(packet.enchantment).getLevel(packet.enchantmentLevel).asItemStack();
 
-        boolean hasEnoughCost = player.isCreative() ||
-                (requiredLapisCost.isEmpty() ||
-                        (lapisSlotStack.is(requiredLapisCost.getItem()) && lapisSlotStack.getCount() >= requiredLapisCost.getCount()))
-                        && (requiredItemCostStack.isEmpty() ||
-                        (costSlotItemStack.is(requiredItemCostStack.getItem()) &&
-                                costSlotItemStack.getCount() >= requiredItemCostStack.getCount()));
+            ItemStack requiredLapisCost = EnchantmentCostRegistry.getServerRegistry().getLapisCost();
+            ItemStack lapisSlotStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem();
 
+            hasEnoughCost = player.isCreative() ||
+                    (requiredLapisCost.isEmpty() ||
+                            (lapisSlotStack.is(requiredLapisCost.getItem()) && lapisSlotStack.getCount() >= requiredLapisCost.getCount()))
+                            && (requiredItemCostStack.isEmpty() ||
+                            (costSlotItemStack.is(requiredItemCostStack.getItem()) &&
+                                    costSlotItemStack.getCount() >= requiredItemCostStack.getCount()));
+        }
 
         if (hasEnoughCost) {
             if (!player.isCreative()) {
-                enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem()
-                        .shrink(requiredLapisCost.getCount()); //Use enchantmnet cost registry
-                if (!requiredItemCostStack.isEmpty()) {
-                    costSlotItemStack.shrink(requiredItemCostStack.getCount()); //Use enchantment cost if not air
+                if (ServerConfig.isXpCostModeEnabled()) {
+                    player.giveExperienceLevels(-xpLevelCost);
+                } else {
+                    ItemStack costSlotItemStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.COST.ordinal()).getItem();
+                    ItemStack requiredItemCostStack = EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(packet.enchantment).getLevel(packet.enchantmentLevel).asItemStack();
+                    ItemStack requiredLapisCost = EnchantmentCostRegistry.getServerRegistry().getLapisCost();
+                    enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem()
+                            .shrink(requiredLapisCost.getCount()); //Use enchantment cost registry
+                    if (!requiredItemCostStack.isEmpty()) {
+                        costSlotItemStack.shrink(requiredItemCostStack.getCount()); //Use enchantment cost if not air
+                    }
                 }
             }
 
@@ -103,9 +116,8 @@ public class ServerPayloadHandler {
 
             player.awardStat(Stats.ENCHANT_ITEM);
             if (player instanceof ServerPlayer serverPlayer) {
-                // Number is levels spent - using 1 to as a compatible default value
-                // (Adjust if optional enchantment cost extensions in the future may include xp cost)
-                CriteriaTriggers.ENCHANTED_ITEM.trigger(serverPlayer, itemToEnchant, 1);
+                int levelsSpent = ServerConfig.isXpCostModeEnabled() ? xpLevelCost : 1;
+                CriteriaTriggers.ENCHANTED_ITEM.trigger(serverPlayer, itemToEnchant, levelsSpent);
             }
 
             if (packet.enchantmentLevel == EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(packet.enchantment).getHighestLevel()) {

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
@@ -74,7 +74,11 @@ public class ServerPayloadHandler {
         boolean hasEnoughCost;
 
         if (ServerConfig.isXpCostModeEnabled()) {
-            hasEnoughCost = player.isCreative() || player.experienceLevel >= xpLevelCost;
+            ItemStack requiredLapisCost = EnchantmentCostRegistry.getServerRegistry().getLapisCost();
+            ItemStack lapisSlotStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem();
+            boolean hasEnoughLapis = requiredLapisCost.isEmpty() ||
+                    (lapisSlotStack.is(requiredLapisCost.getItem()) && lapisSlotStack.getCount() >= requiredLapisCost.getCount());
+            hasEnoughCost = player.isCreative() || (player.experienceLevel >= xpLevelCost && hasEnoughLapis);
         } else {
             ItemStack costSlotItemStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.COST.ordinal()).getItem();
             ItemStack requiredItemCostStack = EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(packet.enchantment).getLevel(packet.enchantmentLevel).asItemStack();
@@ -94,6 +98,11 @@ public class ServerPayloadHandler {
             if (!player.isCreative()) {
                 if (ServerConfig.isXpCostModeEnabled()) {
                     player.giveExperienceLevels(-xpLevelCost);
+                    ItemStack requiredLapisCost = EnchantmentCostRegistry.getServerRegistry().getLapisCost();
+                    if (!requiredLapisCost.isEmpty()) {
+                        enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.LAPIS.ordinal()).getItem()
+                                .shrink(requiredLapisCost.getCount());
+                    }
                 } else {
                     ItemStack costSlotItemStack = enchantingTableMenu.getSlot(EnchantingTableMenu.SLOTS.COST.ordinal()).getItem();
                     ItemStack requiredItemCostStack = EnchantmentCostRegistry.getServerRegistry().getEnchantmentCost(packet.enchantment).getLevel(packet.enchantmentLevel).asItemStack();

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
@@ -71,7 +71,9 @@ public class ServerPayloadHandler {
         );
 
         //Check enchantment cost
-        final int xpLevelCost = packet.enchantmentLevel * 3;
+        // Single-tier enchantments (max level 1) get a flat 9 XP level cost in XP mode.
+        int effectiveLevel = (enchantment.get().getMaxLevel() == 1) ? 3 : packet.enchantmentLevel;
+        final int xpLevelCost = effectiveLevel * 3;
         boolean hasEnoughCost;
 
         if (ServerConfig.isXpCostModeEnabled()) {

--- a/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/ServerPayloadHandler.java
@@ -39,6 +39,7 @@ import net.minecraftforge.network.NetworkEvent;
 import net.minecraftforge.network.PacketDistributor;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -175,18 +176,18 @@ public class ServerPayloadHandler {
     public static void checkBookshelvesAndUpdateClient(BlockPos tablePos, Level level, ServerPlayer serverPlayer) {
         List<BlockEntity> bookshelves = getChiseledBookshelvesNearby(tablePos, level);
 
-        //Store resource locations as strings - i.e "minecraft:respiration"
-        List<ResourceKey<Enchantment>> unlockedEnchantments = new ArrayList<>();
+        // Track the highest found level per enchantment key
+        Map<ResourceKey<Enchantment>, Integer> highestFoundLevel = new HashMap<>();
+
         for (BlockEntity bookshelf : bookshelves) {
             List<ItemStack> books = getChiseledBookshelfContents(bookshelf);
 
-            //Get books in bookshelf
             for (ItemStack book : books) {
                 if (book.getItem() == ModItems.ANCIENT_BOOK.get()) {
                     ResourceKey<Enchantment> key = AncientBook.getEnchantment(book, level);
-
                     if (key != null) {
-                        unlockedEnchantments.add(key);
+                        // Ancient books have no level concept - treat as level 1
+                        highestFoundLevel.merge(key, 1, Math::max);
                     }
                 } else if (ServerConfig.isVanillaBookModeEnabled() && book.getItem() instanceof EnchantedBookItem) {
                     ListTag storedEnchantments = EnchantedBookItem.getEnchantments(book);
@@ -195,32 +196,46 @@ public class ServerPayloadHandler {
                         ResourceLocation enchantmentRL = ResourceLocation.tryParse(tag.getString("id"));
                         if (enchantmentRL != null) {
                             ResourceKey<Enchantment> key = ResourceKey.create(Registries.ENCHANTMENT, enchantmentRL);
-                            unlockedEnchantments.add(key);
+                            int bookLevel = tag.getShort("lvl");
+                            highestFoundLevel.merge(key, bookLevel, Math::max);
                         }
                     }
                 }
             }
         }
 
-        //Unlock all enchantments if creative bookshelf is near
-        if (isCreativeBookshelfNearby(tablePos, level) || !ServerConfig.areAncientBooksRequired()) {
-            //Clear unlockedEnchantments from the bookshelf search
-            unlockedEnchantments.clear();
+        // Build final parallel lists applying bookUnlockMode
+        List<ResourceKey<Enchantment>> enchantmentKeys = new ArrayList<>();
+        List<Integer> maxLevels = new ArrayList<>();
 
-            //Add all enchantments that exist
+        //Unlock all enchantments if creative bookshelf is near or books not required
+        if (isCreativeBookshelfNearby(tablePos, level) || !ServerConfig.areAncientBooksRequired()) {
             RegistryAccess registryAccess = level.registryAccess();
             Registry<Enchantment> enchantmentRegistry = ImmersiveEnchanting.getEnchantmentRegistry(registryAccess);
-            List<Holder.Reference<Enchantment>> allEnchantments = enchantmentRegistry.asLookup().listElements().toList();
-
-            // Convert each Holder to its ResourceLocation string
-            unlockedEnchantments = allEnchantments.stream()
-                    .map(Holder.Reference::key)
-                    .toList();
+            enchantmentRegistry.asLookup().listElements().forEach(holder -> {
+                enchantmentKeys.add(holder.key());
+                maxLevels.add(Integer.MAX_VALUE);
+            });
+        } else {
+            int unlockMode = ServerConfig.getBookUnlockMode();
+            for (Map.Entry<ResourceKey<Enchantment>, Integer> entry : highestFoundLevel.entrySet()) {
+                enchantmentKeys.add(entry.getKey());
+                if (unlockMode == 0) {
+                    // Restrictive: only the exact level found
+                    maxLevels.add(entry.getValue());
+                } else if (unlockMode == 1) {
+                    // Default: all levels up to and including the found level
+                    maxLevels.add(entry.getValue());
+                } else {
+                    // Permissive: all levels
+                    maxLevels.add(Integer.MAX_VALUE);
+                }
+            }
         }
 
         ModPacketHandler.INSTANCE.send(
                 PacketDistributor.PLAYER.with(() -> serverPlayer),
-                new UnlockedEnchantmentsPacket(unlockedEnchantments)
+                new UnlockedEnchantmentsPacket(enchantmentKeys, maxLevels)
         );
     }
 

--- a/src/main/java/me/alfie/immersiveenchanting/networking/packets/EnchantmentCostRegistrySyncPacket.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/packets/EnchantmentCostRegistrySyncPacket.java
@@ -1,5 +1,6 @@
 package me.alfie.immersiveenchanting.networking.packets;
 
+import me.alfie.immersiveenchanting.config.ServerConfig;
 import me.alfie.immersiveenchanting.datapack.EnchantmentCost;
 import me.alfie.immersiveenchanting.datapack.EnchantmentCostRegistry;
 import me.alfie.immersiveenchanting.datapack.LevelCost;
@@ -28,6 +29,7 @@ public class EnchantmentCostRegistrySyncPacket {
     public final List<Integer> amounts;
     public final String lapisCostItemId;
     public final int lapisCostAmount;
+    public final boolean xpCostMode;
 
     public EnchantmentCostRegistrySyncPacket(
             List<String> enchantmentNamespaces,
@@ -35,13 +37,15 @@ public class EnchantmentCostRegistrySyncPacket {
             List<String> itemIds,
             List<Integer> amounts,
             String lapisCostItemId,
-            int lapisCostAmount) {
+            int lapisCostAmount,
+            boolean xpCostMode) {
         this.enchantmentNamespaces = enchantmentNamespaces;
         this.levels = levels;
         this.itemIds = itemIds;
         this.amounts = amounts;
         this.lapisCostItemId = lapisCostItemId;
         this.lapisCostAmount = lapisCostAmount;
+        this.xpCostMode = xpCostMode;
     }
 
     public static void encode(EnchantmentCostRegistrySyncPacket packet, FriendlyByteBuf buf) {
@@ -51,6 +55,7 @@ public class EnchantmentCostRegistrySyncPacket {
         buf.writeCollection(packet.amounts, FriendlyByteBuf::writeInt);
         buf.writeUtf(packet.lapisCostItemId);
         buf.writeInt(packet.lapisCostAmount);
+        buf.writeBoolean(packet.xpCostMode);
     }
 
     public static EnchantmentCostRegistrySyncPacket decode(FriendlyByteBuf buf) {
@@ -60,13 +65,15 @@ public class EnchantmentCostRegistrySyncPacket {
         List<Integer> amounts = buf.readList(FriendlyByteBuf::readInt);
         String lapisCostItemId = buf.readUtf();
         int lapisCostAmount = buf.readInt();
+        boolean xpCostMode = buf.readBoolean();
         return new EnchantmentCostRegistrySyncPacket(
                 enchantmentNamespaces,
                 levels,
                 itemIds,
                 amounts,
                 lapisCostItemId,
-                lapisCostAmount
+                lapisCostAmount,
+                xpCostMode
         );
     }
 
@@ -84,7 +91,7 @@ public class EnchantmentCostRegistrySyncPacket {
      * @param serializedRegistry
      * @return
      */
-    public static EnchantmentCostRegistry deserialize(SerializedEnchantmentCostRegistry serializedRegistry) {
+    public static EnchantmentCostRegistry deserialize(SerializedEnchantmentCostRegistry serializedRegistry, boolean xpCostMode) {
         EnchantmentCostRegistry enchantmentCostRegistry = new EnchantmentCostRegistry();
 
         //For each namespace in the parallel list
@@ -104,6 +111,7 @@ public class EnchantmentCostRegistrySyncPacket {
             enchantmentCost.levels.put(level, levelCost);
         }
 
+        enchantmentCostRegistry.setXpCostMode(xpCostMode);
         return enchantmentCostRegistry;
     }
 
@@ -127,7 +135,8 @@ public class EnchantmentCostRegistrySyncPacket {
                         serializedRegistry.itemIds(),
                         serializedRegistry.amounts(),
                         serializedRegistry.lapisCostItemId(),
-                        serializedRegistry.lapisCostAmount()
+                        serializedRegistry.lapisCostAmount(),
+                        ServerConfig.isXpCostModeEnabled()
                 ));
     }
 

--- a/src/main/java/me/alfie/immersiveenchanting/networking/packets/UnlockedEnchantmentsPacket.java
+++ b/src/main/java/me/alfie/immersiveenchanting/networking/packets/UnlockedEnchantmentsPacket.java
@@ -12,19 +12,27 @@ import java.util.function.Supplier;
 
 public class UnlockedEnchantmentsPacket {
 
+    /**
+     * Parallel lists mapping each enchantment key to its max unlocked level.
+     * A maxLevel of Integer.MAX_VALUE means all levels are unlocked.
+     */
     public final List<ResourceKey<Enchantment>> enchantments;
+    public final List<Integer> maxLevels;
 
-    public UnlockedEnchantmentsPacket(List<ResourceKey<Enchantment>> enchantments) {
+    public UnlockedEnchantmentsPacket(List<ResourceKey<Enchantment>> enchantments, List<Integer> maxLevels) {
         this.enchantments = enchantments;
+        this.maxLevels = maxLevels;
     }
 
     public static void encode(UnlockedEnchantmentsPacket packet, FriendlyByteBuf buf) {
         buf.writeCollection(packet.enchantments, FriendlyByteBuf::writeResourceKey);
+        buf.writeCollection(packet.maxLevels, FriendlyByteBuf::writeInt);
     }
 
     public static UnlockedEnchantmentsPacket decode(FriendlyByteBuf buf) {
         List<ResourceKey<Enchantment>> enchantments = buf.readList(b -> b.readResourceKey(Registries.ENCHANTMENT));
-        return new UnlockedEnchantmentsPacket(enchantments);
+        List<Integer> maxLevels = buf.readList(FriendlyByteBuf::readInt);
+        return new UnlockedEnchantmentsPacket(enchantments, maxLevels);
     }
 
     public static void handle(UnlockedEnchantmentsPacket packet, Supplier<NetworkEvent.Context> contextSupplier) {


### PR DESCRIPTION
1. vanillaBookMode (default: off)
Disables Ancient Book injection into loot pools and stops enchanted books from being removed. Regular enchanted books can be placed in chiseled bookshelves to unlock enchantments, with each stored enchantment and its level being read from the book. Ancient books will still work.

-Should remedy issues with other mods' disabled enchantments still being added as ancient books, and potentially solve compatibility issues with other mods.
-Should be helpful to modpacks that have other methods of obtaining enchanted books or enchantments, other than loot pools/exploration.
-Wll be helpful to those who want to remain as true to vanilla as possible
-Will also make it so finding duplicates of the same enchantment will still be beneficial since the player can use duplicate books at the anvil to enchant with lower cost. 

2. xpCostMode (default: off)
Replaces material costs with XP levels at tier × 3 per enchantment tier. Single-tier enchantments (max level 1) cost a flat 9 levels. Lapis is still always required alongside XP, at increased lapis costs. The tooltip shows the XP cost + lapis icon. The flag is synced server → client via the existing cost registry packet.

-Should make it so that XP is no longer useless for players who still want to use XP as the resource rather than materials.
-Lapis becomes more valuable.
-Keeps brewing ingredients to brewing, enchanting separate.
-Makes XP easier to manage, since XP level requirements are gone, but XP costs are slightly higher, meaning players do not have to worry as much about keeping high XP levels, but keeps XP valuable.

3. bookUnlockMode (default: 1)
Controls how many levels of an enchantment are unlocked when a book is placed in a nearby bookshelf:

0 — Only the exact level of the found book is unlocked
1 — All levels up to and including the book's level are unlocked
2 — All levels of the enchantment are unlocked regardless of book level
This required threading level data through the entire unlock pipeline — from the bookshelf scan on the server, through the network packet, into the menu, and down to individual nodes in the GUI branch renderer.

-Gives players more control over their unlock mechanics
-Default set to 1, making it more exciting and meaningful to find high level enchanted books

4. ModConfig.Type.COMMON generates the file as immersiveenchanting-common.toml in the global config/ folder, so it's set once and applies to every world rather than being stored inside each world's save data. 

-This will make it much easier for modpack authors to configure this mod for the pack.

 