### PR TITLE
Keep items inside the enchanting table and animation for item

### DIFF
--- a/src/main/java/me/alfie/immersiveenchanting/ImmersiveEnchantingClient.java
+++ b/src/main/java/me/alfie/immersiveenchanting/ImmersiveEnchantingClient.java
@@ -1,15 +1,42 @@
 package me.alfie.immersiveenchanting;
 
+import me.alfie.immersiveenchanting.client.EnchantingTableItemRenderer;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.client.event.EntityRenderersEvent;
 import net.neoforged.neoforge.client.gui.ConfigurationScreen;
 import net.neoforged.neoforge.client.gui.IConfigScreenFactory;
 
+/**
+ * Client-only mod entrypoint.
+ *
+ * <p>Registers:</p>
+ * <ul>
+ *     <li>The configuration screen extension point (unchanged).</li>
+ *     <li>{@link EnchantingTableItemRenderer} as the block-entity renderer for
+ *         {@link BlockEntityType#ENCHANTING_TABLE}, which extends the vanilla
+ *         renderer and additionally draws the floating items stored on the
+ *         block entity by {@code EnchantingTableBlockEntityMixin}.</li>
+ * </ul>
+ *
+ * <p>The renderer registration is done via {@link EventBusSubscriber} on the
+ * mod event bus so it doesn't depend on the exact constructor signature
+ * NeoForge expects for the client mod class.</p>
+ */
 @Mod(value = ImmersiveEnchanting.MODID, dist = Dist.CLIENT)
+@EventBusSubscriber(modid = ImmersiveEnchanting.MODID, bus = EventBusSubscriber.Bus.MOD, value = Dist.CLIENT)
 public class ImmersiveEnchantingClient {
 
     public ImmersiveEnchantingClient(ModContainer container) {
         container.registerExtensionPoint(IConfigScreenFactory.class, ConfigurationScreen::new);
+    }
+
+    @SubscribeEvent
+    public static void registerBlockEntityRenderers(EntityRenderersEvent.RegisterRenderers event) {
+        event.registerBlockEntityRenderer(BlockEntityType.ENCHANTING_TABLE, EnchantingTableItemRenderer::new);
     }
 }

--- a/src/main/java/me/alfie/immersiveenchanting/client/EnchantingTableItemRenderer.java
+++ b/src/main/java/me/alfie/immersiveenchanting/client/EnchantingTableItemRenderer.java
@@ -1,0 +1,96 @@
+package me.alfie.immersiveenchanting.client;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Axis;
+import me.alfie.immersiveenchanting.util.IEnchantingTableInventory;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.MultiBufferSource;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.blockentity.EnchantTableRenderer;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.util.Mth;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.EnchantingTableBlockEntity;
+
+/**
+ * Block-entity renderer that draws the tool to enchant floating above the
+ * enchanting table, tied to the book opening animation so the item fades in
+ * and grows as the book opens, then settles into a hover-and-spin idle.
+ *
+ * <p>Extends {@link EnchantTableRenderer} so the vanilla book animation is
+ * preserved unchanged; the floating item is drawn on top after the super
+ * call.</p>
+ */
+public class EnchantingTableItemRenderer extends EnchantTableRenderer {
+
+    public EnchantingTableItemRenderer(BlockEntityRendererProvider.Context context) {
+        super(context);
+    }
+
+    @Override
+    public void render(EnchantingTableBlockEntity blockEntity, float partialTicks, PoseStack poseStack,
+                       MultiBufferSource bufferIn, int combinedLightIn, int combinedOverlayIn) {
+        // Vanilla book first.
+        super.render(blockEntity, partialTicks, poseStack, bufferIn, combinedLightIn, combinedOverlayIn);
+
+        if (!(blockEntity instanceof IEnchantingTableInventory inventory)) return;
+
+        ItemStack tool = inventory.immersive$getItem(0);
+        if (tool.isEmpty()) return;
+
+        // Skip drawing while the book is shut and not animating, so the item
+        // doesn't pop into a closed table.
+        if (blockEntity.open <= 0.0F && blockEntity.oOpen <= 0.0F) return;
+
+        renderFloatingTool(blockEntity, tool, partialTicks, poseStack, bufferIn, combinedLightIn);
+    }
+
+    private void renderFloatingTool(EnchantingTableBlockEntity blockEntity, ItemStack stack,
+                                    float partialTicks, PoseStack poseStack, MultiBufferSource buffer,
+                                    int light) {
+        Minecraft mc = Minecraft.getInstance();
+        BakedModel model = mc.getItemRenderer().getModel(stack, blockEntity.getLevel(), null, 0);
+
+        // Smoothly interpolated openness in [0, 1] coming from the vanilla
+        // book animation — drives the fade-in / grow-in of the item.
+        float openness = Mth.lerp(partialTicks, blockEntity.oOpen, blockEntity.open);
+
+        // Bob: simple sine of the BE clock so the item floats up and down.
+        float clock = blockEntity.time + partialTicks;
+        float bob = Mth.sin(clock / 20.0F) * 0.05F + 0.1F;
+
+        // Vertical offset that accounts for both the bob and an extra lift
+        // proportional to how open the book is, to keep the item seated on
+        // top of the table even with items that have weird ground transforms.
+        float modelYScale = model.getTransforms().getTransform(ItemDisplayContext.GROUND).scale.y();
+        float yLift = bob + 0.25F * modelYScale * openness - 0.15F * (1.0F - openness);
+
+        poseStack.pushPose();
+
+        // Centre on the block top, then lift higher so the item floats above
+        poseStack.translate(0.5F, 1.1F, 0.5F);
+        poseStack.translate(0.0F, yLift, 0.0F);
+
+        // Scale grows with openness so the item appears as the book opens.
+        float scale = openness * 0.8F + 0.2F;
+        poseStack.scale(scale, scale, scale);
+
+        // Spin around vertical axis.
+        poseStack.mulPose(Axis.YP.rotation(clock / 50.0F));
+
+        mc.getItemRenderer().render(
+                stack,
+                ItemDisplayContext.GROUND,
+                false,
+                poseStack,
+                buffer,
+                light,
+                OverlayTexture.NO_OVERLAY,
+                model
+        );
+
+        poseStack.popPose();
+    }
+}

--- a/src/main/java/me/alfie/immersiveenchanting/event/EnchantingTableBreakHandler.java
+++ b/src/main/java/me/alfie/immersiveenchanting/event/EnchantingTableBreakHandler.java
@@ -1,0 +1,54 @@
+package me.alfie.immersiveenchanting.event;
+
+import me.alfie.immersiveenchanting.util.IEnchantingTableInventory;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.Containers;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.EnchantingTableBlockEntity;
+import net.neoforged.neoforge.event.level.BlockEvent;
+
+/**
+ * Drops the persistent enchanting-table inventory when the block is broken.
+ *
+ * <p>Since Immersive Enchanting does not own the enchanting-table block
+ * (it modifies the vanilla one via a Mixin), we hook into the
+ * {@link BlockEvent.BreakEvent} game-bus event to detect breakage and drop
+ * the stored items. After dropping, the slots are cleared to make sure no
+ * duplication can occur.</p>
+ */
+public final class EnchantingTableBreakHandler {
+
+    private EnchantingTableBreakHandler() {
+        // utility class
+    }
+
+    public static void onBlockBreak(BlockEvent.BreakEvent event) {
+        if (event.isCanceled()) return;
+        if (!(event.getLevel() instanceof Level level) || level.isClientSide()) return;
+
+        BlockPos pos = event.getPos();
+        BlockEntity be = level.getBlockEntity(pos);
+        if (!(be instanceof EnchantingTableBlockEntity)) return;
+
+        IEnchantingTableInventory inventory = (IEnchantingTableInventory) be;
+        NonNullList<ItemStack> items = inventory.immersive$getItems();
+
+        boolean anything = false;
+        for (ItemStack stack : items) {
+            if (!stack.isEmpty()) { anything = true; break; }
+        }
+        if (!anything) return;
+
+        // Drop everything at the broken block's position.
+        Containers.dropContents(level, pos, items);
+
+        // Clear the list so nothing can be duplicated if the BE is read again
+        // before unloading.
+        for (int i = 0; i < items.size(); i++) {
+            items.set(i, ItemStack.EMPTY);
+        }
+    }
+}

--- a/src/main/java/me/alfie/immersiveenchanting/event/ModEvents.java
+++ b/src/main/java/me/alfie/immersiveenchanting/event/ModEvents.java
@@ -28,6 +28,8 @@ public class ModEvents {
 
         NeoForge.EVENT_BUS.addListener(NodeSoundsDatapack::registerServerDatapack);
 
+        NeoForge.EVENT_BUS.addListener(EnchantingTableBreakHandler::onBlockBreak);
+
         NeoForge.EVENT_BUS.addListener(ModCommands::registerCommands);
 
         NeoForge.EVENT_BUS.addListener(ImmersiveEnchanting::disableEnchantedBookVillagerTrades);

--- a/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingTableMenu.java
+++ b/src/main/java/me/alfie/immersiveenchanting/gui/EnchantingTableMenu.java
@@ -3,6 +3,7 @@ package me.alfie.immersiveenchanting.gui;
 import me.alfie.immersiveenchanting.datapack.enchantment_cost.CostRegistry;
 import me.alfie.immersiveenchanting.datapack.enchantment_cost.codec.Cost;
 import me.alfie.immersiveenchanting.item.ModItems;
+import me.alfie.immersiveenchanting.util.EnchantingTableContainer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.network.FriendlyByteBuf;
@@ -18,6 +19,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.EnchantingTableBlockEntity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -87,6 +90,19 @@ public class EnchantingTableMenu extends AbstractContainerMenu {
      * <p>Initializes the container, slot layout, and scans for available enchantments
      * if running on the server.</p>
      *
+     * <p>On the server side, when a valid {@link Level} and {@link BlockPos} are
+     * provided and there is an {@link EnchantingTableBlockEntity} at that
+     * position, the menu's container is backed directly by that block entity's
+     * persistent inventory (see {@code EnchantingTableBlockEntityMixin}). This
+     * means items placed in the table stay there after the menu is closed, and
+     * they can be rendered floating above the table by the block-entity
+     * renderer.</p>
+     *
+     * <p>On the client side, where {@code level} and {@code pos} are typically
+     * {@code null} when constructed from the network buffer, a plain
+     * {@link SimpleContainer} is used. Vanilla slot synchronisation packets
+     * still keep the GUI in sync with the server.</p>
+     *
      * @param containerId     The container ID
      * @param playerInventory The player's inventory
      * @param level           The level the menu is operating in
@@ -94,10 +110,22 @@ public class EnchantingTableMenu extends AbstractContainerMenu {
      */
     public EnchantingTableMenu(int containerId, Inventory playerInventory, @Nullable Level level, @Nullable BlockPos pos) {
         super(ModMenus.ENCHANTING_TABLE_MENU.get(), containerId);
-        this.container = new SimpleContainer(3);
         this.blockPos = pos;
         this.level = level;
         this.access = ContainerLevelAccess.create(level, pos);
+
+        // On the server, back the container with the BE so items persist
+        // between menu opens. On the client (or when there's no BE at the
+        // given position) fall back to a plain SimpleContainer.
+        Container chosenContainer = null;
+        if (level != null && !level.isClientSide() && pos != null) {
+            BlockEntity be = level.getBlockEntity(pos);
+            if (be instanceof EnchantingTableBlockEntity enchantingBE) {
+                chosenContainer = new EnchantingTableContainer(enchantingBE);
+            }
+        }
+        this.container = chosenContainer != null ? chosenContainer : new SimpleContainer(3);
+
         buildSlots(playerInventory);
     }
 
@@ -177,10 +205,13 @@ public class EnchantingTableMenu extends AbstractContainerMenu {
         //Quick move into inventory
         if(i == Slots.TOOL.id()) {
             if(!this.moveItemStackTo(stack, 3, 39, true)) return ItemStack.EMPTY;
+            slot.setChanged(); // notify the BE-backed container so the renderer updates
         } else if (i == Slots.ENCHANTING_FUEL.id()) {
             if (!this.moveItemStackTo(stack, 3, 39, true)) return ItemStack.EMPTY;
+            slot.setChanged();
         } else if (i == Slots.COST.id()) {
             if (!this.moveItemStackTo(stack, 3, 39, true)) return ItemStack.EMPTY;
+            slot.setChanged();
         } else {
             CostRegistry registry = CostRegistry.client();
             if(level != null && !level.isClientSide()) {
@@ -230,11 +261,15 @@ public class EnchantingTableMenu extends AbstractContainerMenu {
     /**
      * Called when the menu is closed.
      *
-     * <p>On the server:
-     * <ul>
-     *     <li>All items in the internal container are returned to the player</li>
-     *     <li>If the inventory is full, items are dropped</li>
-     * </ul>
+     * <p>If the container is backed by an {@link EnchantingTableBlockEntity}
+     * (server side), items are intentionally left in the table — the player
+     * can come back later and continue. The block entity's inventory is
+     * dropped only when the block itself is destroyed (handled by
+     * {@code EnchantingTableBreakHandler}).</p>
+     *
+     * <p>If the container is a plain {@link SimpleContainer} (fallback path,
+     * for example if no BE was found at the given position), the items are
+     * returned to the player to avoid losing them.</p>
      *
      * @param player The player closing the menu
      */
@@ -242,12 +277,19 @@ public class EnchantingTableMenu extends AbstractContainerMenu {
     public void removed(@NotNull Player player) {
         super.removed(player);
 
-        if (!player.level().isClientSide()) {
-            for (int i = 0; i < this.container.getContainerSize(); i++) {
-                ItemStack stack = this.container.removeItemNoUpdate(i); //remove without triggering slot update
-                if (!stack.isEmpty()) {
-                    player.getInventory().placeItemBackInInventory(stack); //return to inventory, drop if full
-                }
+        if (player.level().isClientSide()) return;
+
+        // BE-backed container: leave the items in the block. They persist in
+        // NBT and will be visible to the next player who opens the table.
+        if (this.container instanceof EnchantingTableContainer) {
+            return;
+        }
+
+        // Fallback path: return items to the player so they aren't lost.
+        for (int i = 0; i < this.container.getContainerSize(); i++) {
+            ItemStack stack = this.container.removeItemNoUpdate(i);
+            if (!stack.isEmpty()) {
+                player.getInventory().placeItemBackInInventory(stack);
             }
         }
     }

--- a/src/main/java/me/alfie/immersiveenchanting/mixin/EnchantingTableBlockEntityMixin.java
+++ b/src/main/java/me/alfie/immersiveenchanting/mixin/EnchantingTableBlockEntityMixin.java
@@ -1,0 +1,112 @@
+package me.alfie.immersiveenchanting.mixin;
+
+import me.alfie.immersiveenchanting.util.IEnchantingTableInventory;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.core.NonNullList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
+import net.minecraft.world.ContainerHelper;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.EnchantingTableBlockEntity;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * Adds a persistent 3-slot inventory to the vanilla
+ * {@link EnchantingTableBlockEntity} so items dropped in the table by the
+ * Immersive Enchanting menu stay in the world after the menu is closed.
+ *
+ * <p>The inventory:</p>
+ * <ul>
+ *     <li>is stored in the BE's NBT (so it survives chunk unload / world save)</li>
+ *     <li>is sent to the client whenever the BE updates (so the floating-items
+ *         renderer can show them)</li>
+ *     <li>is dropped to the world when the block is broken (handled by
+ *         {@code EnchantingTableBreakHandler}).</li>
+ * </ul>
+ *
+ * <p>Applied as a Mixin onto the vanilla block entity rather than via a
+ * custom subclass, so the rest of the mod (and any other mods) keep seeing
+ * the standard {@code EnchantingTableBlockEntity} type.</p>
+ */
+@Mixin(EnchantingTableBlockEntity.class)
+public abstract class EnchantingTableBlockEntityMixin extends BlockEntity implements IEnchantingTableInventory {
+
+    // Required by the BlockEntity superclass constructor; never actually called
+    // because Mixin doesn't add new constructors. Present only to satisfy javac.
+    private EnchantingTableBlockEntityMixin() {
+        super(null, null, null);
+    }
+
+    @Unique
+    private final NonNullList<ItemStack> immersive$items =
+            NonNullList.withSize(IMMERSIVE_INVENTORY_SIZE, ItemStack.EMPTY);
+
+    @Override
+    public NonNullList<ItemStack> immersive$getItems() {
+        return this.immersive$items;
+    }
+
+    @Override
+    public ItemStack immersive$getItem(int slot) {
+        if (slot < 0 || slot >= IMMERSIVE_INVENTORY_SIZE) return ItemStack.EMPTY;
+        return this.immersive$items.get(slot);
+    }
+
+    @Override
+    public void immersive$setItem(int slot, ItemStack stack) {
+        if (slot < 0 || slot >= IMMERSIVE_INVENTORY_SIZE) return;
+        this.immersive$items.set(slot, stack);
+    }
+
+    @Override
+    public void immersive$setChangedAndSync() {
+        this.setChanged();
+        if (this.level != null && !this.level.isClientSide) {
+            this.level.sendBlockUpdated(this.getBlockPos(), this.getBlockState(), this.getBlockState(), 3);
+        }
+    }
+
+    // ---- NBT persistence ----
+
+    @Inject(method = "saveAdditional", at = @At("TAIL"))
+    private void immersive$saveAdditional(CompoundTag tag, HolderLookup.Provider registries, CallbackInfo ci) {
+        ContainerHelper.saveAllItems(tag, this.immersive$items, true, registries);
+    }
+
+    @Inject(method = "loadAdditional", at = @At("TAIL"))
+    private void immersive$loadAdditional(CompoundTag tag, HolderLookup.Provider registries, CallbackInfo ci) {
+        // Reset to empty before loading so removed slots clear properly.
+        for (int i = 0; i < IMMERSIVE_INVENTORY_SIZE; i++) {
+            this.immersive$items.set(i, ItemStack.EMPTY);
+        }
+        ContainerHelper.loadAllItems(tag, this.immersive$items, registries);
+    }
+
+    // ---- Client sync ----
+    //
+    // Vanilla EnchantingTableBlockEntity does not override getUpdatePacket /
+    // getUpdateTag. By default these return null on a base BlockEntity, so the
+    // client never receives our items. We override both here so the items are
+    // sent on chunk load and on every block update we trigger via setChanged.
+
+    @Override
+    public @Nullable Packet<ClientGamePacketListener> getUpdatePacket() {
+        return ClientboundBlockEntityDataPacket.create(this);
+    }
+
+    @Override
+    public CompoundTag getUpdateTag(HolderLookup.Provider registries) {
+        // saveWithoutMetadata writes the BE's full data (vanilla's customName,
+        // plus our injected items list) without the position/type metadata
+        // that's already known on the client side.
+        return this.saveWithoutMetadata(registries);
+    }
+}

--- a/src/main/java/me/alfie/immersiveenchanting/mixin/EnchantingTableBlockMixin.java
+++ b/src/main/java/me/alfie/immersiveenchanting/mixin/EnchantingTableBlockMixin.java
@@ -1,5 +1,6 @@
 package me.alfie.immersiveenchanting.mixin;
 
+import me.alfie.immersiveenchanting.block.ModBlocks;
 import me.alfie.immersiveenchanting.gui.EnchantingTableMenu;
 import me.alfie.immersiveenchanting.util.BookshelfChecker;
 import net.minecraft.core.BlockPos;
@@ -12,6 +13,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.EnchantingTableBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.ChiseledBookShelfBlockEntity;
 import net.minecraft.world.level.block.entity.EnchantingTableBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
@@ -95,6 +97,61 @@ public abstract class EnchantingTableBlockMixin {
         }
 
 
+    }
+
+    /**
+     * Filters which nearby blocks count as a valid bookshelf for the
+     * enchanting-table particle effect (the floating glyphs that fly from the
+     * shelves to the book).
+     *
+     * <p>Immersive Enchanting replaces vanilla's bookshelf-power system with
+     * one based on chiseled bookshelves containing books. We restrict the
+     * particle source to:</p>
+     * <ul>
+     *     <li>Chiseled bookshelves that contain at least one item, and</li>
+     *     <li>The mod's own creative bookshelf block.</li>
+     * </ul>
+     *
+     * <p>Plain wooden bookshelves are rejected so they don't emit particles.
+     * Empty chiseled bookshelves are rejected too. We must fully handle the
+     * decision here (no fall-through), because vanilla's own logic only
+     * accepts {@code Blocks.BOOKSHELF} and would reject our chiseled / mod
+     * bookshelves if we let it run.</p>
+     */
+    @Inject(method = "isValidBookShelf", at = @At("HEAD"), cancellable = true)
+    private static void immersiveenchanting$isValidBookShelf(Level level, BlockPos pos, BlockPos offset, CallbackInfoReturnable<Boolean> cir) {
+        BlockPos shelfPos = pos.offset(offset);
+        BlockState shelfState = level.getBlockState(shelfPos);
+
+        boolean shelfIsValid = false;
+
+        // Mod's creative bookshelf always counts.
+        if (shelfState.is(ModBlocks.CREATIVE_BOOKSHELF_BLOCK.get())) {
+            shelfIsValid = true;
+        } else {
+            // Chiseled bookshelf with at least one item.
+            BlockEntity be = level.getBlockEntity(shelfPos);
+            if (be instanceof ChiseledBookShelfBlockEntity shelf) {
+                for (int i = 0; i < shelf.getContainerSize(); i++) {
+                    if (!shelf.getItem(i).isEmpty()) {
+                        shelfIsValid = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!shelfIsValid) {
+            cir.setReturnValue(false);
+            return;
+        }
+
+        // Replicate vanilla's "in-between space must be air" check so the
+        // line-of-sight requirement still holds for our valid shelf types.
+        // The in-between position is half-way between the table and the shelf,
+        // at the shelf's Y coordinate.
+        BlockPos inBetween = pos.offset(offset.getX() / 2, offset.getY(), offset.getZ() / 2);
+        cir.setReturnValue(level.getBlockState(inBetween).isAir());
     }
 
 

--- a/src/main/java/me/alfie/immersiveenchanting/util/EnchantingTableContainer.java
+++ b/src/main/java/me/alfie/immersiveenchanting/util/EnchantingTableContainer.java
@@ -1,0 +1,112 @@
+package me.alfie.immersiveenchanting.util;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.entity.EnchantingTableBlockEntity;
+
+/**
+ * A 3-slot {@link net.minecraft.world.Container} backed by the persistent
+ * inventory stored on a vanilla {@link EnchantingTableBlockEntity} via the
+ * {@link IEnchantingTableInventory} mixin interface.
+ *
+ * <p>Used by the server-side menu so that placing an item in the table writes
+ * directly to the block entity, and so that closing the menu does <em>not</em>
+ * lose those items — they live on the BE and survive until the block is
+ * destroyed.</p>
+ *
+ * <p>This subclasses {@link SimpleContainer} only to inherit some of its
+ * trivial behaviour and remain compatible with code that expects a
+ * {@code Container}; every read/write actually overrides to forward to the
+ * BE's stack list.</p>
+ */
+public class EnchantingTableContainer extends SimpleContainer {
+
+    private final EnchantingTableBlockEntity blockEntity;
+    private final IEnchantingTableInventory inventoryView;
+
+    public EnchantingTableContainer(EnchantingTableBlockEntity blockEntity) {
+        // SimpleContainer creates its own NonNullList; we overshadow every
+        // method below so its internal list is never used.
+        super(IEnchantingTableInventory.IMMERSIVE_INVENTORY_SIZE);
+        this.blockEntity = blockEntity;
+        this.inventoryView = (IEnchantingTableInventory) blockEntity;
+    }
+
+    public EnchantingTableBlockEntity getBlockEntity() {
+        return blockEntity;
+    }
+
+    @Override
+    public int getContainerSize() {
+        return IEnchantingTableInventory.IMMERSIVE_INVENTORY_SIZE;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        for (ItemStack stack : inventoryView.immersive$getItems()) {
+            if (!stack.isEmpty()) return false;
+        }
+        return true;
+    }
+
+    @Override
+    public ItemStack getItem(int slot) {
+        return inventoryView.immersive$getItem(slot);
+    }
+
+    @Override
+    public ItemStack removeItem(int slot, int amount) {
+        NonNullList<ItemStack> items = inventoryView.immersive$getItems();
+        ItemStack stack = items.get(slot);
+        if (stack.isEmpty() || amount <= 0) return ItemStack.EMPTY;
+        ItemStack split = stack.split(amount);
+        if (stack.isEmpty()) {
+            items.set(slot, ItemStack.EMPTY);
+        }
+        this.setChanged();
+        return split;
+    }
+
+    @Override
+    public ItemStack removeItemNoUpdate(int slot) {
+        NonNullList<ItemStack> items = inventoryView.immersive$getItems();
+        ItemStack stack = items.get(slot);
+        if (stack.isEmpty()) return ItemStack.EMPTY;
+        items.set(slot, ItemStack.EMPTY);
+        return stack;
+    }
+
+    @Override
+    public void setItem(int slot, ItemStack stack) {
+        inventoryView.immersive$setItem(slot, stack);
+        this.setChanged();
+    }
+
+    @Override
+    public void setChanged() {
+        // Push a block update so clients receive the new contents and the
+        // BlockEntityRenderer can show the floating items.
+        inventoryView.immersive$setChangedAndSync();
+    }
+
+    @Override
+    public boolean stillValid(Player player) {
+        if (blockEntity.isRemoved()) return false;
+        return player.distanceToSqr(
+                blockEntity.getBlockPos().getX() + 0.5,
+                blockEntity.getBlockPos().getY() + 0.5,
+                blockEntity.getBlockPos().getZ() + 0.5
+        ) <= 64.0;
+    }
+
+    @Override
+    public void clearContent() {
+        NonNullList<ItemStack> items = inventoryView.immersive$getItems();
+        for (int i = 0; i < items.size(); i++) {
+            items.set(i, ItemStack.EMPTY);
+        }
+        this.setChanged();
+    }
+}

--- a/src/main/java/me/alfie/immersiveenchanting/util/IEnchantingTableInventory.java
+++ b/src/main/java/me/alfie/immersiveenchanting/util/IEnchantingTableInventory.java
@@ -1,0 +1,45 @@
+package me.alfie.immersiveenchanting.util;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Interface implemented (via Mixin / duck-typing) by the vanilla
+ * {@link net.minecraft.world.level.block.entity.EnchantingTableBlockEntity}
+ * to expose a persistent 3-slot inventory that survives menu close.
+ *
+ * <p>The slot layout matches the one used by Immersive Enchanting's
+ * {@code EnchantingTableMenu}:</p>
+ * <ul>
+ *     <li>0 – Tool / item to enchant</li>
+ *     <li>1 – Enchanting fuel (lapis lazuli, etc.)</li>
+ *     <li>2 – Cost / catalyst item</li>
+ * </ul>
+ *
+ * <p>Cast a vanilla {@code EnchantingTableBlockEntity} to this interface to
+ * read or write the persistent stacks. The implementation lives in
+ * {@code EnchantingTableBlockEntityMixin}.</p>
+ */
+public interface IEnchantingTableInventory {
+
+    int IMMERSIVE_INVENTORY_SIZE = 3;
+
+    /**
+     * @return the live, mutable backing list of three item stacks. Mutating
+     *         elements directly should be followed by a call to
+     *         {@link #immersive$setChangedAndSync()} so the client is kept
+     *         in sync with the new contents.
+     */
+    NonNullList<ItemStack> immersive$getItems();
+
+    ItemStack immersive$getItem(int slot);
+
+    void immersive$setItem(int slot, ItemStack stack);
+
+    /**
+     * Marks the BE dirty and pushes a block update so that clients receive the
+     * new stacks via {@code getUpdatePacket}/{@code getUpdateTag}, which in
+     * turn drives the floating-items renderer.
+     */
+    void immersive$setChangedAndSync();
+}

--- a/src/main/resources/immersiveenchanting.mixins.json
+++ b/src/main/resources/immersiveenchanting.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "EnchantingTableBlockMixin",
+    "EnchantingTableBlockEntityMixin",
     "ItemStackMixin"
   ],
   "injectors": {


### PR DESCRIPTION
Items stays inside the enchanting table and the tool/weapon renders over the enchanting table with a simple floating animation.